### PR TITLE
Backfill missing lab metadata (4 files)

### DIFF
--- a/Instructions/Labs/LAB_01_create_microsoft_sentinel_workspace.md
+++ b/Instructions/Labs/LAB_01_create_microsoft_sentinel_workspace.md
@@ -1,7 +1,15 @@
 ---
 lab:
-    title: 'Exercise 01: Deploy Microsoft Sentinel'
-    module: 'Guided Project - Create and configure a Microsoft Sentinel workspace'
+  title: 'Exercise 01: Deploy Microsoft Sentinel'
+  module: Guided Project - Create and configure a Microsoft Sentinel workspace
+  description: We are currently evaluating the existing security posture of our corporate
+    environment. We need your help in setting up a security information and event
+    management (SIEM) solution to help identify future and ongoing cyber-attacks.
+  duration: 30 minutes
+  level: 400
+  islab: true
+  primarytopics:
+  - Microsoft Sentinel
 ---
 
 >**Note**: To complete this lab, you will need an [Azure subscription.](https://azure.microsoft.com/en-us/free/?azure-portal=true) in which you have administrative access.

--- a/Instructions/Labs/LAB_02_deploy_microsoft_sentinel_content_hub_solution.md
+++ b/Instructions/Labs/LAB_02_deploy_microsoft_sentinel_content_hub_solution.md
@@ -1,7 +1,17 @@
 ---
 lab:
-    title: 'Exercise 02: Ingest Windows Security event data'
-    module: 'Guided Project - Deploy Microsoft Sentinel Content Hub solutions and data connectors'
+  title: 'Exercise 02: Ingest Windows Security event data'
+  module: Guided Project - Deploy Microsoft Sentinel Content Hub solutions and data
+    connectors
+  description: We need configure Microsoft Sentinel to ingest data by using Microsoft
+    Sentinel solutions.
+  duration: 45 minutes
+  level: 400
+  islab: true
+  primarytopics:
+  - Microsoft Sentinel
+  - Windows
+  - Windows Security
 ---
 
 >**Note**: This lab builds on Lab 01. To complete this lab, you will need an [Azure subscription.](https://azure.microsoft.com/free/?azure-portal=true) in which you have administrative access.

--- a/Instructions/Labs/LAB_03_validate-microsoft_sentinel_deploymnent.md
+++ b/Instructions/Labs/LAB_03_validate-microsoft_sentinel_deploymnent.md
@@ -1,7 +1,16 @@
 ---
 lab:
-    title: 'Exercise 03: Validate the Sentinel Deployment'
-    module: 'Guided Project - Configure Microsoft Sentinel Data Collection rules, NRT Analytic rule and Automation'
+  title: 'Exercise 03: Validate the Sentinel Deployment'
+  module: Guided Project - Configure Microsoft Sentinel Data Collection rules, NRT
+    Analytic rule and Automation
+  description: We need to configure Microsoft Sentinel to receive security events
+    from virtual machines that run Windows.
+  duration: 20 minutes
+  level: 400
+  islab: true
+  primarytopics:
+  - Microsoft Sentinel
+  - Windows
 ---
 
 >**Note**: This lab builds on Lab 01 and Lab 02. To complete this lab, you will need an [Azure subscription.](https://azure.microsoft.com/free/?azure-portal=true) in which you have administrative access.

--- a/Instructions/Labs/LAB_04_perform_analytic_rule_validation.md
+++ b/Instructions/Labs/LAB_04_perform_analytic_rule_validation.md
@@ -1,7 +1,16 @@
 ---
 lab:
-    title: 'Exercise 04: Perform simulated attack'
-    module: 'Guided Project - Perform a simulated attack to validate Analytic and Automation rules'
+  title: 'Exercise 04: Perform simulated attack'
+  module: Guided Project - Perform a simulated attack to validate Analytic and Automation
+    rules
+  description: We need to validate that our Microsoft Sentinel deployment is receiving
+    security events and creating incidents from virtual machines that run Windows.
+  duration: 10 minutes
+  level: 300
+  islab: true
+  primarytopics:
+  - Microsoft Sentinel
+  - Windows
 ---
 
 >**Note**: This lab builds on Labs 01, 02 and 03. To complete this lab, you will need an [Azure subscription.](https://azure.microsoft.com/free/?azure-portal=true) in which you have administrative access.


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 4

- `Instructions/Labs/LAB_01_create_microsoft_sentinel_workspace.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_02_deploy_microsoft_sentinel_content_hub_solution.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_03_validate-microsoft_sentinel_deploymnent.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_04_perform_analytic_rule_validation.md` (description,duration,level,islab,primarytopics)
