### PR TITLE
Backfill missing lab metadata (4 files)

### DIFF
--- a/Instructions/Labs/LAB_01_create_microsoft_sentinel_workspace.md
+++ b/Instructions/Labs/LAB_01_create_microsoft_sentinel_workspace.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Exercise 01: Deploy Microsoft Sentinel'
-    module: 'Guided Project - Create and configure a Microsoft Sentinel workspace'
+  title: 'Exercise 01: Deploy Microsoft Sentinel'
+  module: Guided Project - Create and configure a Microsoft Sentinel workspace
+  description: Deploy Microsoft Sentinel to the workspace.
+  duration: 30 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Microsoft Sentinel
 ---
 
 >**Note**: To complete this lab, you will need an [Azure subscription.](https://azure.microsoft.com/en-us/free/?azure-portal=true) in which you have administrative access.

--- a/Instructions/Labs/LAB_02_deploy_microsoft_sentinel_content_hub_solution.md
+++ b/Instructions/Labs/LAB_02_deploy_microsoft_sentinel_content_hub_solution.md
@@ -1,7 +1,15 @@
 ---
 lab:
-    title: 'Exercise 02: Ingest Windows Security event data'
-    module: 'Guided Project - Deploy Microsoft Sentinel Content Hub solutions and data connectors'
+  title: 'Exercise 02: Ingest Windows Security event data'
+  module: Guided Project - Deploy Microsoft Sentinel Content Hub solutions and data connectors
+  description: We need configure Microsoft Sentinel to ingest data by using Microsoft Sentinel solutions.
+  duration: 45 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Microsoft Sentinel
+    - Windows
+    - Windows Security
 ---
 
 >**Note**: This lab builds on Lab 01. To complete this lab, you will need an [Azure subscription.](https://azure.microsoft.com/free/?azure-portal=true) in which you have administrative access.

--- a/Instructions/Labs/LAB_03_validate-microsoft_sentinel_deploymnent.md
+++ b/Instructions/Labs/LAB_03_validate-microsoft_sentinel_deploymnent.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Exercise 03: Validate the Sentinel Deployment'
-    module: 'Guided Project - Configure Microsoft Sentinel Data Collection rules, NRT Analytic rule and Automation'
+  title: 'Exercise 03: Validate the Sentinel Deployment'
+  module: Guided Project - Configure Microsoft Sentinel Data Collection rules, NRT Analytic rule and Automation
+  description: 'You need to validate the Microsoft Sentinel deployment to meet the following requirements:'
+  duration: 20 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Microsoft Sentinel
 ---
 
 >**Note**: This lab builds on Lab 01 and Lab 02. To complete this lab, you will need an [Azure subscription.](https://azure.microsoft.com/free/?azure-portal=true) in which you have administrative access.

--- a/Instructions/Labs/LAB_04_perform_analytic_rule_validation.md
+++ b/Instructions/Labs/LAB_04_perform_analytic_rule_validation.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Exercise 04: Perform simulated attack'
-    module: 'Guided Project - Perform a simulated attack to validate Analytic and Automation rules'
+  title: 'Exercise 04: Perform simulated attack'
+  module: Guided Project - Perform a simulated attack to validate Analytic and Automation rules
+  description: You need to perform a simulated attack to validate that the Analytic and Automation rules create an incident and assign it to the Operator1. You will perform a simple Privilege Escalation attack on vm1.
+  duration: 10 minutes
+  level: 300
+  islab: true
 ---
 
 >**Note**: This lab builds on Labs 01, 02 and 03. To complete this lab, you will need an [Azure subscription.](https://azure.microsoft.com/free/?azure-portal=true) in which you have administrative access.


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 4

- `Instructions/Labs/LAB_01_create_microsoft_sentinel_workspace.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_02_deploy_microsoft_sentinel_content_hub_solution.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_03_validate-microsoft_sentinel_deploymnent.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_04_perform_analytic_rule_validation.md` (description,duration,level,islab)
